### PR TITLE
Handle UIResponse buttons in CLI menu

### DIFF
--- a/AI CAP/chatbrain/cli/menu.py
+++ b/AI CAP/chatbrain/cli/menu.py
@@ -60,7 +60,12 @@ def simulate_chat() -> None:
             normalized = "Huỷ"
         response = service.handle_message(session_id, normalized)
         print(f"Bot: {response.reply}")
-        buttons = response.ui.get("buttons") if isinstance(response.ui, dict) else None
+        ui = response.ui
+        buttons = None
+        if ui is not None:
+            buttons = getattr(ui, "buttons", None)
+            if buttons is None and hasattr(ui, "get"):
+                buttons = ui.get("buttons")
         if buttons:
             print("Nút gợi ý:", ", ".join(buttons))
         print("Top-k:", json.dumps(response.debug.get("top_k", []), ensure_ascii=False, indent=2))


### PR DESCRIPTION
## Summary
- update the CLI simulator to read suggestion buttons from UIResponse objects
- fall back to `.get("buttons")` when the UI payload only exposes a mapping API

## Testing
- python -m chatbrain.cli.menu *(fails: requires NLU index and valid scripts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2908058d4832db6a71098cb144ccb