### PR TITLE
Fix cu_tru module registry path

### DIFF
--- a/AI CAP/registry.yaml
+++ b/AI CAP/registry.yaml
@@ -16,7 +16,7 @@ modules:
       - "xem_canh_bao_toi_pham"
 
   - name: cu_tru
-    path: "knowledge_base/scripts/02_thu_tuc_cu_tru.yaml"
+    path: "knowledge_base/scripts/02_xac_nhan_cu_tru.yaml"
     intents:
       - "xac_nhan_thong_tin_cu_tru"
 


### PR DESCRIPTION
## Summary
- update the cu_tru module entry to point to the correct 02_xac_nhan_cu_tru.yaml script

## Testing
- pytest chatbrain/tests/test_interrupt_flow.py
- pytest chatbrain/tests/test_nlu_match.py

------
https://chatgpt.com/codex/tasks/task_e_68e2907d2e70832db0a52d8538edf1be