### PR TITLE
Fix system intents structure in VNeID script

### DIFF
--- a/AI CAP/knowledge_base/scripts/01_vneid.yaml
+++ b/AI CAP/knowledge_base/scripts/01_vneid.yaml
@@ -985,6 +985,7 @@ intents:
 - id: user_confirms_step
   intent: user_confirms_step
   system: true
+  domain: system
   can_interrupt: false
   synonyms:
   - ok
@@ -999,10 +1000,13 @@ intents:
   version: 1
   examples: []
   required_slots: []
-  steps: []
+  steps:
+  - id: s1_ack
+    say: ""
 - id: user_denies_step
   intent: user_denies_step
   system: true
+  domain: system
   can_interrupt: false
   synonyms:
   - không
@@ -1012,10 +1016,13 @@ intents:
   version: 1
   examples: []
   required_slots: []
-  steps: []
+  steps:
+  - id: s1_ack
+    say: ""
 - id: user_requests_previous_step
   intent: user_requests_previous_step
   system: true
+  domain: system
   can_interrupt: false
   synonyms:
   - quay lại
@@ -1024,10 +1031,13 @@ intents:
   version: 1
   examples: []
   required_slots: []
-  steps: []
+  steps:
+  - id: s1_ack
+    say: ""
 - id: fallback
   intent: fallback
   system: true
+  domain: system
   steps:
   - id: s1_ask_clarification
     say: Tôi chưa hiểu rõ câu hỏi của anh/chị. Có phải anh/chị đang muốn hỏi về một


### PR DESCRIPTION
## Summary
- add missing `domain: system` metadata to VNeID system intents so they satisfy the schema
- provide minimal acknowledgement steps for system intents that previously had empty step lists

## Testing
- USE_EMBEDDING=false USE_SQLITE_LOG=false pytest chatbrain/tests -q
- python - <<'PY'
from chatbrain.core.loader import load_from_folder
import tempfile, shutil
import os
with tempfile.TemporaryDirectory() as tmp:
    shutil.copy('knowledge_base/scripts/01_vneid.yaml', tmp)
    pack = load_from_folder(tmp)
    print('Loaded', len(pack.intents), 'intents from 01_vneid')
PY


------
https://chatgpt.com/codex/tasks/task_e_68e2921bce68832daea5d5f0f6003bbb